### PR TITLE
Update .gitpod.Dockerfile

### DIFF
--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -3,7 +3,7 @@ SHELL ["/bin/bash", "-c"]
 
 ENV ANDROID_HOME=/home/gitpod/androidsdk \
     FLUTTER_VERSION=2.2.3-stable \
-    ANDROID_BUILD_TOOLS_VERSION=34.0.0 
+    ANDROID_BUILD_TOOLS_VERSION=34.0.0
     # <--- Define your desired build tools version here
 
 USER root
@@ -34,9 +34,29 @@ RUN apt update
 # Replaced 'install-packages' with standard 'apt install -y'.
 RUN apt install -y build-essential dart libkrb5-dev gcc make gradle android-tools-adb android-tools-fastboot
 
-# Install Open JDK 8
-RUN apt install -y openjdk-8-jdk \
-    && update-java-alternatives --set java-1.8.0-openjdk-amd64
+# Install Open JDK 17
+RUN apt install -y openjdk-17-jdk
+
+# Set OpenJDK 17 as the default Java version.
+# Verify this exact path in your build if you encounter issues.
+# A common path for OpenJDK 17 on Debian-based systems is /usr/lib/jvm/java-17-openjdk-amd64
+RUN update-java-alternatives --set java-1.17.0-openjdk-amd64
+
+# --- ADDED SECTION FOR JAVA_HOME ---
+# Determine the correct JAVA_HOME path.
+# This command finds the path pointed to by the 'java' alternative.
+# It then sets the JAVA_HOME environment variable to this path.
+RUN export JAVA_HOME=$(readlink -f /usr/bin/java | sed "s:jre/bin/java::;s:bin/java::") \
+    && echo "export JAVA_HOME=$JAVA_HOME" >> /home/gitpod/.bashrc \
+    && echo 'export PATH="$JAVA_HOME/bin:$PATH"' >> /home/gitpod/.bashrc
+
+# Optional: Add JAVA_HOME to /etc/environment for system-wide availability (less common for user-specific dev setup)
+# RUN echo "JAVA_HOME=$JAVA_HOME" >> /etc/environment
+
+# Verify the Java version and JAVA_HOME during the build process
+RUN java -version
+RUN echo $JAVA_HOME
+# --- END ADDED SECTION ---
 
 # Install Google Chrome stable version.
 RUN apt install -y google-chrome-stable
@@ -78,11 +98,9 @@ RUN wget https://dl.google.com/android/repository/commandlinetools-linux-7583922
 RUN echo "export ANDROID_HOME=$ANDROID_HOME" >> /home/gitpod/.bashrc \
     && echo 'export PATH=$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH' >> /home/gitpod/.bashrc
 
-# --- ADD THIS SECTION ---
 # Install Android SDK Build-Tools using sdkmanager
 # We use the ANDROID_BUILD_TOOLS_VERSION variable for clarity and easy updates.
 RUN yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"
-# --- END ADDITION ---
 
 # Install Android platform-tools, platform 30, and emulator.
 RUN yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-30" "emulator"

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -4,63 +4,83 @@ SHELL ["/bin/bash", "-c"]
 ENV ANDROID_HOME=/home/gitpod/androidsdk \
     FLUTTER_VERSION=2.2.3-stable
 
-# Install dart
 USER root
-RUN curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | apt-key add - \
-    && curl -fsSL https://storage.googleapis.com/download.dartlang.org/linux/debian/dart_stable.list > /etc/apt/sources.list.d/dart_stable.list \
-    && install-packages build-essential dart libkrb5-dev gcc make gradle android-tools-adb android-tools-fastboot
 
-# Install flutter
-USER gitpod
-RUN cd /home/gitpod \
-    && wget https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}.tar.xz \
-    && tar -xvf flutter*.tar.xz \
-    && rm -f flutter*.tar.xz
+# Create directory for apt keyrings to store GPG keys securely
+RUN mkdir -p /etc/apt/keyrings
 
-RUN flutter/bin/flutter precache
-RUN echo 'export PATH="$PATH:/home/gitpod/flutter/bin"' >> /home/gitpod/.bashrc
+# Attempt to remove any problematic Nginx PPA source lists.
+# This PPA seems to be causing a "404 Not Found" error.
+# The 'find ... -delete' ensures all matching files are removed.
+RUN find /etc/apt/sources.list.d/ -name "*nginx-mainline*.list" -delete || true
 
-# Install Open JDK
-USER root
-RUN apt update \
-    && apt install openjdk-8-jdk -y \
+# Configure Dart repository using the modern apt key handling method.
+# The GPG key is downloaded and processed with 'gpg --dearmor' to ensure
+# it's in the correct binary format for 'signed-by'.
+RUN curl -fsSL https://dl-ssl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/dart-archive-keyring.gpg \
+    && echo "deb [signed-by=/etc/apt/keyrings/dart-archive-keyring.gpg] https://storage.googleapis.com/download.dartlang.org/linux/debian stable main" > /etc/apt/sources.list.d/dart_stable.list
+
+# Configure Google Chrome repository using the modern apt key handling method.
+# Similar to Dart, the key is processed with 'gpg --dearmor'.
+RUN curl -fsSL https://dl.google.com/linux/linux_signing_key.pub | gpg --dearmor -o /etc/apt/keyrings/google-chrome-keyring.gpg \
+    && echo "deb [arch=amd64 signed-by=/etc/apt/keyrings/google-chrome-keyring.gpg] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list
+
+# Update package lists after all repositories have been added and configured.
+RUN apt update
+
+# Install build essential packages, Dart, and other dependencies.
+# Replaced 'install-packages' with standard 'apt install -y'.
+RUN apt install -y build-essential dart libkrb5-dev gcc make gradle android-tools-adb android-tools-fastboot
+
+# Install Open JDK 8
+RUN apt install -y openjdk-8-jdk \
     && update-java-alternatives --set java-1.8.0-openjdk-amd64
 
-# Install SDK Manager
-USER gitpod
-RUN  wget https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip \
-    && mkdir -p $ANDROID_HOME/cmdline-tools/latest \
-    && unzip commandlinetools-linux-*.zip -d $ANDROID_HOME \
-    && rm -f commandlinetools-linux-*.zip \
-    && mv $ANDROID_HOME/cmdline-tools/bin $ANDROID_HOME/cmdline-tools/latest \
-    && mv $ANDROID_HOME/cmdline-tools/lib $ANDROID_HOME/cmdline-tools/latest
+# Install Google Chrome stable version.
+RUN apt install -y google-chrome-stable
 
-RUN echo "export ANDROID_HOME=$ANDROID_HOME" >> /home/gitpod/.bashrc \
-    && echo 'export PATH=$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/cmdline-tools/bin:$ANDROID_HOME/platform-tools:$PATH' >> /home/gitpod/.bashrc
-
-# Install Android Image version 30
-USER gitpod
-RUN yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-30" "emulator"
-RUN yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "system-images;android-30;google_apis;x86_64"
-RUN echo no | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd -n avd28 -k "system-images;android-30;google_apis;x86_64"
-
-
-# Install Google Chrome
-USER root
-RUN apt-get update \
-  && apt-get install -y apt-transport-https \
-  && curl -sSL https://dl.google.com/linux/linux_signing_key.pub | apt-key add - \
-  && echo "deb [arch=amd64] https://dl.google.com/linux/chrome/deb/ stable main" > /etc/apt/sources.list.d/google-chrome.list \
-  && apt-get update \
-  && sudo apt-get install -y google-chrome-stable
-
-# misc deps
-RUN apt-get install -y \
+# Install miscellaneous dependencies required for Flutter and other tools.
+RUN apt install -y \
   libasound2-dev \
   libgtk-3-dev \
   libnss3-dev \
   fonts-noto \
   fonts-noto-cjk
 
-# For Qt WebEngine on docker
-ENV QTWEBENGINE_DISABLE_SANDBOX 1
+USER gitpod
+
+# Install Flutter: download, extract, and remove archive.
+RUN cd /home/gitpod \
+    && wget https://storage.googleapis.com/flutter_infra_release/releases/stable/linux/flutter_linux_${FLUTTER_VERSION}.tar.xz \
+    && tar -xvf flutter*.tar.xz \
+    && rm -f flutter*.tar.xz
+
+# Precache Flutter artifacts. Using absolute path for flutter command.
+RUN /home/gitpod/flutter/bin/flutter precache
+
+# Add Flutter to the user's bashrc PATH for future interactive sessions.
+RUN echo 'export PATH="$PATH:/home/gitpod/flutter/bin"' >> /home/gitpod/.bashrc
+
+# Install Android SDK Command-line Tools.
+RUN wget https://dl.google.com/android/repository/commandlinetools-linux-7583922_latest.zip \
+    && mkdir -p $ANDROID_HOME/cmdline-tools/latest \
+    && unzip commandlinetools-linux-*.zip -d $ANDROID_HOME \
+    && rm -f commandlinetools-linux-*.zip \
+    && mv $ANDROID_HOME/cmdline-tools/bin $ANDROID_HOME/cmdline-tools/latest \
+    && mv $ANDROID_HOME/cmdline-tools/lib $ANDROID_HOME/cmdline-tools/latest
+
+# Add Android SDK paths to the user's bashrc for future interactive sessions.
+RUN echo "export ANDROID_HOME=$ANDROID_HOME" >> /home/gitpod/.bashrc \
+    && echo 'export PATH=$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/cmdline-tools/bin:$ANDROID_HOME/platform-tools:$PATH' >> /home/gitpod/.bashrc
+
+# Install Android platform-tools, platform 30, and emulator.
+RUN yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-30" "emulator"
+
+# Install Android system image for API 30 (Google APIs, x86_64).
+RUN yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "system-images;android-30;google_apis;x86_64"
+
+# Create an Android Virtual Device (AVD) named avd28 using the installed system image.
+RUN echo no | $ANDROID_HOME/cmdline-tools/latest/bin/avdmanager create avd -n avd28 -k "system-images;android-30;google_apis;x86_64"
+
+# Set environment variable for Qt WebEngine, fixing the format.
+ENV QTWEBENGINE_DISABLE_SANDBOX=1

--- a/.gitpod.Dockerfile
+++ b/.gitpod.Dockerfile
@@ -2,7 +2,9 @@ FROM gitpod/workspace-full-vnc
 SHELL ["/bin/bash", "-c"]
 
 ENV ANDROID_HOME=/home/gitpod/androidsdk \
-    FLUTTER_VERSION=2.2.3-stable
+    FLUTTER_VERSION=2.2.3-stable \
+    ANDROID_BUILD_TOOLS_VERSION=34.0.0 
+    # <--- Define your desired build tools version here
 
 USER root
 
@@ -70,8 +72,17 @@ RUN wget https://dl.google.com/android/repository/commandlinetools-linux-7583922
     && mv $ANDROID_HOME/cmdline-tools/lib $ANDROID_HOME/cmdline-tools/latest
 
 # Add Android SDK paths to the user's bashrc for future interactive sessions.
+# This should also include the build-tools path, though for a Dockerfile build step,
+# it's often more reliable to use the full path or ensure it's on the PATH
+# for the specific RUN command, as we will below.
 RUN echo "export ANDROID_HOME=$ANDROID_HOME" >> /home/gitpod/.bashrc \
-    && echo 'export PATH=$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/cmdline-tools/bin:$ANDROID_HOME/platform-tools:$PATH' >> /home/gitpod/.bashrc
+    && echo 'export PATH=$ANDROID_HOME/emulator:$ANDROID_HOME/tools:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH' >> /home/gitpod/.bashrc
+
+# --- ADD THIS SECTION ---
+# Install Android SDK Build-Tools using sdkmanager
+# We use the ANDROID_BUILD_TOOLS_VERSION variable for clarity and easy updates.
+RUN yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "build-tools;${ANDROID_BUILD_TOOLS_VERSION}"
+# --- END ADDITION ---
 
 # Install Android platform-tools, platform 30, and emulator.
 RUN yes | $ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager "platform-tools" "platforms;android-30" "emulator"


### PR DESCRIPTION
Fix: Resolve Dockerfile build failures and apt issues

This commit addresses several critical issues preventing the Dockerfile from building successfully:

- **Resolved `apt update` errors:**
    - Removed the problematic `nginx-mainline` PPA that was causing `404 Not Found` errors.
    - Corrected the GPG key installation for Dart and Google Chrome repositories, resolving "NO_PUBKEY" and "not signed" errors by properly processing keys with `gpg --dearmor` and referencing them via `signed-by`.

- **Improved Dockerfile practices:**
    - Consolidated `apt update` calls for efficiency.
    - Replaced the Gitpod-specific `install-packages` with the standard `apt install -y`.
    - Corrected the format of the `ENV` variable `QTWEBENGINE_DISABLE_SANDBOX`.
    - Ensured Flutter commands use absolute paths for reliability during the build process.

These changes ensure a more stable and successful Gitpod workspace image build.